### PR TITLE
Upgrade ramda from 0.29 to 0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@graphql-codegen/typescript-resolvers": "^5.1.7",
         "@types/mjml": "^4.7.1",
         "@types/node": "^18.11.18",
-        "@types/ramda": "^0.30.2",
+        "@types/ramda": "^0.31.1",
         "prisma": "^6.19.3",
         "tsx": "^4.21.0",
         "typescript": "^5.2.2"
@@ -3206,13 +3206,13 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@types/ramda": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
-      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "types-ramda": "^0.30.1"
+        "types-ramda": "^0.31.0"
       }
     },
     "node_modules/@types/request": {
@@ -9248,9 +9248,9 @@
       }
     },
     "node_modules/types-ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
-      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11806,12 +11806,12 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@types/ramda": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
-      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
       "dev": true,
       "requires": {
-        "types-ramda": "^0.30.1"
+        "types-ramda": "^0.31.0"
       }
     },
     "@types/request": {
@@ -16055,9 +16055,9 @@
       }
     },
     "types-ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
-      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
       "dev": true,
       "requires": {
         "ts-toolbelt": "^9.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "handlebars": "^4.7.8",
         "mailersend": "^2.2.0",
         "mjml": "^4.14.1",
-        "ramda": "^0.29.0",
+        "ramda": "^0.32.0",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -29,7 +29,7 @@
         "@graphql-codegen/typescript-resolvers": "^5.1.7",
         "@types/mjml": "^4.7.1",
         "@types/node": "^18.11.18",
-        "@types/ramda": "^0.29.3",
+        "@types/ramda": "^0.30.2",
         "prisma": "^6.19.3",
         "tsx": "^4.21.0",
         "typescript": "^5.2.2"
@@ -3206,12 +3206,13 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@types/ramda": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.3.tgz",
-      "integrity": "sha512-Yh/RHkjN0ru6LVhSQtTkCRo6HXkfL9trot/2elzM/yXLJmbLm2v6kJc8yftTnwv1zvUob6TEtqI2cYjdqG3U0Q==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "types-ramda": "^0.29.4"
+        "types-ramda": "^0.30.1"
       }
     },
     "node_modules/@types/request": {
@@ -8331,9 +8332,10 @@
       ]
     },
     "node_modules/ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -9163,7 +9165,8 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -9245,10 +9248,11 @@
       }
     },
     "node_modules/types-ramda": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.4.tgz",
-      "integrity": "sha512-XO/820iRsCDwqLjE8XE+b57cVGPyk1h+U9lBGpDWvbEky+NQChvHVwaKM05WnW1c5z3EVQh8NhXFmh2E/1YazQ==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
       }
@@ -11802,12 +11806,12 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@types/ramda": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.3.tgz",
-      "integrity": "sha512-Yh/RHkjN0ru6LVhSQtTkCRo6HXkfL9trot/2elzM/yXLJmbLm2v6kJc8yftTnwv1zvUob6TEtqI2cYjdqG3U0Q==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
       "dev": true,
       "requires": {
-        "types-ramda": "^0.29.4"
+        "types-ramda": "^0.30.1"
       }
     },
     "@types/request": {
@@ -15426,9 +15430,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA=="
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ=="
     },
     "raw-body": {
       "version": "3.0.2",
@@ -16051,9 +16055,9 @@
       }
     },
     "types-ramda": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.4.tgz",
-      "integrity": "sha512-XO/820iRsCDwqLjE8XE+b57cVGPyk1h+U9lBGpDWvbEky+NQChvHVwaKM05WnW1c5z3EVQh8NhXFmh2E/1YazQ==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
       "dev": true,
       "requires": {
         "ts-toolbelt": "^9.6.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@graphql-codegen/typescript-resolvers": "^5.1.7",
     "@types/mjml": "^4.7.1",
     "@types/node": "^18.11.18",
-    "@types/ramda": "^0.29.3",
+    "@types/ramda": "^0.30.2",
     "prisma": "^6.19.3",
     "tsx": "^4.21.0",
     "typescript": "^5.2.2"
@@ -46,7 +46,7 @@
     "handlebars": "^4.7.8",
     "mailersend": "^2.2.0",
     "mjml": "^4.14.1",
-    "ramda": "^0.29.0",
+    "ramda": "^0.32.0",
     "winston": "^3.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@graphql-codegen/typescript-resolvers": "^5.1.7",
     "@types/mjml": "^4.7.1",
     "@types/node": "^18.11.18",
-    "@types/ramda": "^0.30.2",
+    "@types/ramda": "^0.31.1",
     "prisma": "^6.19.3",
     "tsx": "^4.21.0",
     "typescript": "^5.2.2"


### PR DESCRIPTION
## Summary
- Upgrades `ramda` from 0.29.0 to 0.32.0
- Upgrades `@types/ramda` from 0.29.3 to 0.30.x
- No code changes needed — only `remove` and `prop` are used, neither affected by breaking changes

## Breaking changes in 0.30+ (not relevant to us)
- Placeholder testing now uses strict equality (`===`)
- We don't use placeholders anywhere

## Test plan
- [x] Verify the server starts without errors
- [x] Test wish reordering (uses `remove`) and wish list queries (uses `prop`)