### PR TITLE
Upgrade TypeScript from 5.x to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/ramda": "^0.31.1",
         "prisma": "^6.19.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.2.2"
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -9424,9 +9424,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16245,9 +16245,9 @@
       }
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/ramda": "^0.31.1",
     "prisma": "^6.19.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.2.2"
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "@apollo/server": "^5.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "preserve" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.x to 6.0.2
- Update `module` from `commonjs` to `preserve` and `moduleResolution` from `node` (deprecated `node10`) to `bundler` to resolve the TS6 deprecation
- These settings match the tsx-based runtime used by the project

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Verify dev server starts correctly with `npm run dev`